### PR TITLE
Ensure Electron CSP stays aligned with backend overrides

### DIFF
--- a/zoom-video-app/config/backend-url.js
+++ b/zoom-video-app/config/backend-url.js
@@ -1,0 +1,56 @@
+const DEFAULT_BACKEND_FALLBACK = 'http://localhost:4000';
+
+const ensureHttpProtocol = (value) => {
+  if (!value) {
+    return '';
+  }
+
+  const trimmed = `${value}`.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  if (!/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed)) {
+    return `http://${trimmed}`;
+  }
+
+  return trimmed;
+};
+
+const stripTrailingSlashes = (value) => value.replace(/\/+$/, '');
+
+const normalizeBackendUrl = (input) => {
+  const ensured = ensureHttpProtocol(input);
+  if (!ensured) {
+    return '';
+  }
+
+  try {
+    const url = new URL(ensured);
+    url.hash = '';
+    url.search = '';
+    return stripTrailingSlashes(url.toString());
+  } catch (error) {
+    return stripTrailingSlashes(ensured);
+  }
+};
+
+const getBackendOrigin = (value) => {
+  const ensured = ensureHttpProtocol(value);
+  if (!ensured) {
+    return '';
+  }
+
+  try {
+    return new URL(ensured).origin;
+  } catch (error) {
+    return '';
+  }
+};
+
+module.exports = {
+  DEFAULT_BACKEND_FALLBACK,
+  ensureHttpProtocol,
+  normalizeBackendUrl,
+  getBackendOrigin,
+};

--- a/zoom-video-app/config/connect-src.js
+++ b/zoom-video-app/config/connect-src.js
@@ -1,0 +1,33 @@
+const CONNECT_SRC_BASE = [
+  "'self'",
+  'data:',
+  'blob:',
+  'ws://localhost:*',
+  'wss://localhost:*',
+  'http://localhost:*',
+  'https://localhost:*',
+  'https://zoom.us',
+  'https://*.zoom.us',
+  'https://source.zoom.us',
+  'https://api.zoom.us',
+  'https://marketplace.zoom.us',
+  'https://*.zoomgov.com',
+  'https://zoomgov.com',
+  'wss://*.zoom.us',
+  'wss://*.zoomgov.com',
+  'https://*.zoomus.cn',
+  'wss://*.zoomus.cn',
+];
+
+const buildConnectSrcValues = (...extraSources) => {
+  const values = new Set(CONNECT_SRC_BASE);
+  extraSources.filter(Boolean).forEach((source) => {
+    values.add(source);
+  });
+  return values;
+};
+
+module.exports = {
+  CONNECT_SRC_BASE,
+  buildConnectSrcValues,
+};

--- a/zoom-video-app/forge.config.js
+++ b/zoom-video-app/forge.config.js
@@ -1,39 +1,23 @@
 // zoom-video-app/forge.config.js
 const { FusesPlugin } = require('@electron-forge/plugin-fuses');
 const { FuseV1Options, FuseVersion } = require('@electron/fuses');
+const {
+  DEFAULT_BACKEND_FALLBACK,
+  ensureHttpProtocol,
+  getBackendOrigin,
+} = require('./config/backend-url');
+const { buildConnectSrcValues } = require('./config/connect-src');
 
-const backendEnvUrl = process.env.BACKEND_BASE_URL || process.env.TOKEN_SERVER_URL || 'http://localhost:4000';
-let backendOrigin = '';
-try {
-  backendOrigin = new URL(backendEnvUrl).origin;
-} catch (error) {
+const backendEnvUrl = ensureHttpProtocol(
+  process.env.BACKEND_BASE_URL || process.env.TOKEN_SERVER_URL || DEFAULT_BACKEND_FALLBACK,
+);
+
+let backendOrigin = getBackendOrigin(backendEnvUrl);
+if (!backendOrigin) {
   backendOrigin = backendEnvUrl;
 }
 
-const connectSrcValues = new Set([
-  "'self'",
-  'data:',
-  'blob:',
-  'ws://localhost:*',
-  'wss://localhost:*',
-  'http://localhost:*',
-  'https://localhost:*',
-  'https://zoom.us',
-  'https://*.zoom.us',
-  'https://source.zoom.us',
-  'https://api.zoom.us',
-  'https://marketplace.zoom.us',
-  'https://*.zoomgov.com',
-  'https://zoomgov.com',
-  'wss://*.zoom.us',
-  'wss://*.zoomgov.com',
-  'https://*.zoomus.cn',
-  'wss://*.zoomus.cn',
-]);
-
-if (backendOrigin) {
-  connectSrcValues.add(backendOrigin);
-}
+const connectSrcValues = buildConnectSrcValues(backendOrigin);
 
 const devContentSecurityPolicy = [
   "default-src 'self' 'unsafe-inline' data: blob:;",


### PR DESCRIPTION
## Summary
- add shared helpers for backend URL normalization and connect-src base sources
- use the shared helpers in the Forge configuration so the development CSP always includes the normalized backend origin
- recompute and inject the connect-src allowlist in the Electron main process based on environment defaults and stored overrides to prevent backend requests from being blocked

## Testing
- npm --prefix zoom-video-app run lint

------
https://chatgpt.com/codex/tasks/task_e_68df63665f8883328e4fd3d333f12e45