### PR TITLE
Align meeting flow with Zoom Meeting SDK guidance

### DIFF
--- a/zoom-video-app/src/index.css
+++ b/zoom-video-app/src/index.css
@@ -599,7 +599,8 @@ body {
   justify-content: flex-end;
 }
 
-.video-tile video {
+.video-tile video,
+.video-tile canvas {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -623,6 +624,7 @@ body {
 }
 
 .share-canvas-wrapper {
+  position: relative;
   border-radius: 20px;
   overflow: hidden;
   background: rgba(9, 14, 30, 0.7);


### PR DESCRIPTION
## Summary
- initialize the Zoom Video SDK with the documented CDN lib path and validate audio/video start results when joining sessions
- harden meeting lifecycle handling by cleaning share/video canvases, reacting to share and connection events, and honoring share privilege rules before toggling screen sharing
- ensure remote video tiles and the share canvas follow the SDK rendering guidance so passive share stops and video toggles release their canvases cleanly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df72290d308332ba0f71588316ad88