### PR TITLE
Add shareable meeting links and link-based join flow

### DIFF
--- a/zoom-video-app/src/App.jsx
+++ b/zoom-video-app/src/App.jsx
@@ -123,19 +123,26 @@ function App() {
         return defaultBackendUrl;
     }, [clearBackendOverride, defaultBackendUrl]);
 
-    const joinMeeting = useCallback((name, user) => {
-        if (!backendUrl) {
-            alert('백엔드 서버 주소가 구성되지 않았습니다. 먼저 연결 설정을 완료해주세요.');
-            return;
-        }
-        if (!name || !user) {
-            alert('세션 이름과 사용자 이름을 입력해주세요.');
-            return;
-        }
-        setSessionName(name);
-        setUserName(user);
-        setIsInMeeting(true);
-    }, [backendUrl]);
+    const joinMeeting = useCallback(
+        (name, user, backendOverride) => {
+            const normalizedOverride = normalizeBackendUrl(backendOverride);
+            const effectiveBackend = normalizedOverride || backendUrl;
+
+            if (!effectiveBackend) {
+                alert('백엔드 서버 주소가 구성되지 않았습니다. 먼저 연결 설정을 완료해주세요.');
+                return;
+            }
+            if (!name || !user) {
+                alert('세션 이름과 사용자 이름을 입력해주세요.');
+                return;
+            }
+
+            setSessionName(name);
+            setUserName(user);
+            setIsInMeeting(true);
+        },
+        [backendUrl],
+    );
 
     const leaveMeeting = useCallback(async () => {
         setIsInMeeting(false);

--- a/zoom-video-app/src/index.css
+++ b/zoom-video-app/src/index.css
@@ -312,6 +312,13 @@ body {
   color: var(--color-text-muted);
 }
 
+.form-helper-text {
+  margin: 8px 0 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--color-text-muted);
+}
+
 .backend-status-message {
   margin: 12px 0 0;
   font-size: 14px;
@@ -521,11 +528,66 @@ body {
   gap: 28px;
 }
 
-.meeting-header {
+.meeting-header { 
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 16px;
+}
+
+.share-link-panel {
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 24px;
+  padding: 20px 24px;
+  backdrop-filter: blur(24px);
+  box-shadow: 0 18px 36px rgba(8, 12, 24, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.share-link-input {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: stretch;
+}
+
+.share-link-input input {
+  flex: 1 1 280px;
+  min-width: 0;
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  font-size: 15px;
+  background: rgba(15, 23, 42, 0.65);
+  color: #e2e8f0;
+}
+
+.share-link-input input:focus {
+  outline: none;
+  border-color: rgba(81, 207, 102, 0.6);
+  box-shadow: 0 0 0 3px rgba(81, 207, 102, 0.25);
+}
+
+.share-link-description {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(226, 232, 255, 0.72);
+}
+
+.share-link-status {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.share-link-status--success {
+  color: rgba(81, 207, 102, 0.85);
+}
+
+.share-link-status--error {
+  color: rgba(240, 82, 82, 0.85);
 }
 
 .meeting-header h1 {

--- a/zoom-video-app/src/utils/backend.js
+++ b/zoom-video-app/src/utils/backend.js
@@ -38,3 +38,54 @@ export const getBackendLabel = (url) => {
         return normalized.replace(/^https?:\/\//, '');
     }
 };
+
+export const parseJoinLink = (input) => {
+    if (!input) {
+        return null;
+    }
+
+    const trimmed = `${input}`.trim();
+    if (!trimmed) {
+        return null;
+    }
+
+    let url;
+    try {
+        url = new URL(trimmed);
+    } catch (error) {
+        return null;
+    }
+
+    const sessionName =
+        url.searchParams.get('sessionName') ||
+        url.searchParams.get('session') ||
+        url.searchParams.get('meeting') ||
+        url.searchParams.get('topic');
+
+    if (!sessionName) {
+        return null;
+    }
+
+    const explicitBackendParam = url.searchParams.get('backendUrl') || url.searchParams.get('backend');
+
+    let backendUrl = normalizeBackendUrl(explicitBackendParam);
+
+    if (!backendUrl) {
+        const pathnameWithoutTrailingSlash = url.pathname.replace(/\/+$/, '');
+        const basePath = pathnameWithoutTrailingSlash.replace(/\/join$/, '');
+        backendUrl = normalizeBackendUrl(`${url.origin}${basePath}`);
+    }
+
+    const displayName =
+        url.searchParams.get('userName') ||
+        url.searchParams.get('displayName') ||
+        url.searchParams.get('name') ||
+        '';
+
+    return {
+        sessionName,
+        backendUrl,
+        joinUrl: url.toString(),
+        displayName,
+    };
+};


### PR DESCRIPTION
## Summary
- add a shareable meeting link panel with clipboard support in the meeting screen
- let the lobby accept full join URLs by parsing session/backend info and updating the backend configuration
- expose a `/join` helper endpoint on the token server with guidance HTML for copied links and supporting styles/utilities

## Testing
- not run (Electron app requires a display environment)


------
https://chatgpt.com/codex/tasks/task_e_68df7b378ba083328c1311fe35706265