### PR TITLE
Avoid importing Zoom Video SDK package.json

### DIFF
--- a/zoom-video-app/src/MeetingScreen.jsx
+++ b/zoom-video-app/src/MeetingScreen.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import ZoomVideo, { SharePrivilege, VideoQuality } from '@zoom/videosdk';
-import zoomVideoSdkPackageJson from '@zoom/videosdk/package.json';
 import { normalizeBackendUrl } from './utils/backend';
 
 const APP_KEY = process.env.ZOOM_SDK_KEY;
@@ -30,11 +29,6 @@ const resolveSdkVersion = () => {
     const sdkReportedVersion = sanitizeString(ZoomVideo?.VERSION);
     if (sdkReportedVersion) {
         return sdkReportedVersion;
-    }
-
-    const packageJsonVersion = sanitizeString(zoomVideoSdkPackageJson?.version);
-    if (packageJsonVersion) {
-        return packageJsonVersion;
     }
 
     return 'latest';


### PR DESCRIPTION
## Summary
- remove the import of `@zoom/videosdk/package.json` from the meeting screen so webpack no longer requests a non-exported path
- keep the Zoom SDK version resolution by falling back to environment variables, the SDK-reported version, or `latest`

## Testing
- npm run start *(fails in this environment because the Electron app requires an interactive display)*

------
https://chatgpt.com/codex/tasks/task_e_68df8d5d22e4833280108de575240c6f