### PR TITLE
Ensure Zoom SDK assets load under Electron CSP constraints

### DIFF
--- a/zoom-video-app/webpack.renderer.config.js
+++ b/zoom-video-app/webpack.renderer.config.js
@@ -87,6 +87,12 @@ module.exports = {
         {
           from: path.resolve(__dirname, 'node_modules/@zoom/videosdk/dist/lib'),
           to: 'lib',
+          noErrorOnMissing: true,
+        },
+        {
+          from: path.resolve(__dirname, 'node_modules/@zoom/videosdk/dist/lib'),
+          to: path.posix.join('main_window', 'lib'),
+          noErrorOnMissing: true,
         },
       ],
     }),


### PR DESCRIPTION
## Summary
- prioritize bundled Zoom Video SDK assets when running under Electron or strict CSP rules and resolve their runtime paths safely
- add runtime helpers to detect CSP limitations before trying remote CDNs
- copy the Zoom Video SDK lib directory into the renderer entry scope so local requests succeed in development and production

## Testing
- npm --prefix zoom-video-app run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfaa69a40c8332b15bfb245461eb2e