### PR TITLE
Allow Zoom CDN assets in renderer CSP

### DIFF
--- a/zoom-video-app/src/index.html
+++ b/zoom-video-app/src/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta
     http-equiv="Content-Security-Policy"
-    content="default-src 'self' data: blob:; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'unsafe-eval' 'unsafe-inline' data:; connect-src 'self' data: blob: http://localhost:* https://localhost:* https://zoom.us https://*.zoom.us https://source.zoom.us https://api.zoom.us https://marketplace.zoom.us https://*.zoomgov.com https://zoomgov.com https://*.zoomus.cn https://*.zoom.us wss://*.zoom.us wss://*.zoomgov.com wss://*.zoomus.cn ws://localhost:* wss://localhost:* http: https: ws: wss:; frame-src 'self' https://*.zoom.us https://*.zoomgov.com; media-src 'self' blob: data:;"
+    content="default-src 'self' data: blob: https://source.zoom.us; img-src 'self' data: blob: https://source.zoom.us; font-src 'self' https://fonts.gstatic.com data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://source.zoom.us; script-src 'self' 'unsafe-eval' 'unsafe-inline' data: https://source.zoom.us; connect-src 'self' data: blob: http://localhost:* https://localhost:* https://zoom.us https://*.zoom.us https://source.zoom.us https://api.zoom.us https://marketplace.zoom.us https://*.zoomgov.com https://zoomgov.com https://*.zoomus.cn https://*.zoom.us wss://*.zoom.us wss://*.zoomgov.com wss://*.zoomus.cn ws://localhost:* wss://localhost:* http: https: ws: wss:; frame-src 'self' https://*.zoom.us https://*.zoomgov.com; media-src 'self' blob: data:;"
   />
   <title>Zoom English Class</title>
 </head>


### PR DESCRIPTION
## Summary
- allow Zoom Meeting SDK scripts and styles to load by permitting source.zoom.us in the renderer CSP

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0065eb9c083329a79daf350e97c2b