### PR TITLE
Update Meeting SDK loader to use official CDN bundle

### DIFF
--- a/zoom-video-app/src/MeetingScreen.jsx
+++ b/zoom-video-app/src/MeetingScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { loadZoomEmbeddedSdk } from './utils/zoomSdkLoader';
+import { ZOOM_SDK_CDN_BASE, loadZoomEmbeddedSdk } from './utils/zoomSdkLoader';
 
 const STATUS_LABELS = {
     idle: '대기 중',
@@ -131,6 +131,7 @@ export default function MeetingScreen({ meetingContext, onLeaveMeeting }) {
                         zoomAppRoot: zoomRootRef.current,
                         language: 'ko-KR',
                         patchJsMedia: true,
+                        assetPath: ZOOM_SDK_CDN_BASE,
                         customize: {
                             meetingInfo: ['topic', 'host', 'mn', 'pwd', 'participant'],
                             video: { isResizable: true },


### PR DESCRIPTION
## Summary
- load the Zoom Meeting SDK from the official CDN bundle introduced in v3 by swapping to the sdk base URL
- preload Web SDK assets and localization once the script is available to avoid runtime initialization issues
- pass the CDN asset path into the embedded client so initialization uses the bundled resources

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e01821a4f083329955a8410959cfb0