### PR TITLE
Handle Zoom SDK CDN fallback

### DIFF
--- a/zoom-video-app/src/MeetingScreen.jsx
+++ b/zoom-video-app/src/MeetingScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ZOOM_SDK_CDN_BASE, loadZoomEmbeddedSdk } from './utils/zoomSdkLoader';
+import { getZoomSdkAssetBase, loadZoomEmbeddedSdk } from './utils/zoomSdkLoader';
 
 const STATUS_LABELS = {
     idle: '대기 중',
@@ -131,7 +131,7 @@ export default function MeetingScreen({ meetingContext, onLeaveMeeting }) {
                         zoomAppRoot: zoomRootRef.current,
                         language: 'ko-KR',
                         patchJsMedia: true,
-                        assetPath: ZOOM_SDK_CDN_BASE,
+                        assetPath: getZoomSdkAssetBase(),
                         customize: {
                             meetingInfo: ['topic', 'host', 'mn', 'pwd', 'participant'],
                             video: { isResizable: true },

--- a/zoom-video-app/src/utils/zoomSdkLoader.js
+++ b/zoom-video-app/src/utils/zoomSdkLoader.js
@@ -1,27 +1,50 @@
 const SDK_VERSION = '3.10.1';
-const SDK_CDN_BASE = 'https://source.zoom.us/sdk';
+
+const CDN_SOURCES = [
+    {
+        assetPath: 'https://source.zoom.us/meetingsdk',
+        script: `https://source.zoom.us/meetingsdk/zoom-meeting-embedded-${SDK_VERSION}.min.js`,
+        styles: [
+            'https://source.zoom.us/meetingsdk/index.css',
+            'https://source.zoom.us/meetingsdk/embedded/index.css',
+        ],
+    },
+    {
+        assetPath: 'https://dmogdx0jrul3u.cloudfront.net/sdk',
+        script: `https://dmogdx0jrul3u.cloudfront.net/sdk/zoom-meeting-embedded-${SDK_VERSION}.min.js`,
+        styles: [
+            'https://dmogdx0jrul3u.cloudfront.net/sdk/index.css',
+            'https://dmogdx0jrul3u.cloudfront.net/sdk/embedded/index.css',
+        ],
+    },
+    {
+        assetPath: 'https://source.zoom.us/sdk',
+        script: `https://source.zoom.us/sdk/zoom-meeting-embedded-${SDK_VERSION}.min.js`,
+        styles: [
+            'https://source.zoom.us/sdk/index.css',
+            'https://source.zoom.us/sdk/embedded/index.css',
+        ],
+    },
+];
 
 export const ZOOM_SDK_VERSION = SDK_VERSION;
-export const ZOOM_SDK_CDN_BASE = SDK_CDN_BASE;
 
-const SCRIPT_SOURCES = [
-    `${SDK_CDN_BASE}/zoom-meeting-embedded-${SDK_VERSION}.min.js`,
-];
-
-const CSS_SOURCES = [
-    `${SDK_CDN_BASE}/index.css`,
-    `${SDK_CDN_BASE}/embedded/index.css`,
-];
-
+let activeCdn = CDN_SOURCES[0];
 let loadingPromise = null;
+
+export function getZoomSdkAssetBase() {
+    return activeCdn.assetPath;
+}
 
 function appendStylesheet(href) {
     if (typeof document === 'undefined') {
-        return;
+        return null;
     }
 
-    if (document.querySelector(`link[data-zoom-sdk="${href}"]`)) {
-        return;
+    const existing = document.querySelector(`link[data-zoom-sdk="${href}"]`);
+    if (existing) {
+        existing.dataset.loaded = 'true';
+        return existing;
     }
 
     const link = document.createElement('link');
@@ -29,7 +52,14 @@ function appendStylesheet(href) {
     link.href = href;
     link.dataset.zoomSdk = href;
     link.crossOrigin = 'anonymous';
+    link.onload = () => {
+        link.dataset.loaded = 'true';
+    };
+    link.onerror = () => {
+        link.remove();
+    };
     document.head.appendChild(link);
+    return link;
 }
 
 function appendScript(src) {
@@ -40,11 +70,23 @@ function appendScript(src) {
     const existing = document.querySelector(`script[data-zoom-sdk="${src}"]`);
     if (existing) {
         if (existing.dataset.loaded === 'true') {
-            return Promise.resolve();
+            return Promise.resolve(existing);
         }
         return new Promise((resolve, reject) => {
-            existing.addEventListener('load', () => resolve());
-            existing.addEventListener('error', (event) => reject(event?.error || new Error(`Failed to load ${src}`)));
+            const handleLoad = () => {
+                cleanup();
+                resolve(existing);
+            };
+            const handleError = (event) => {
+                cleanup();
+                reject(event?.error || new Error(`Failed to load ${src}`));
+            };
+            const cleanup = () => {
+                existing.removeEventListener('load', handleLoad);
+                existing.removeEventListener('error', handleError);
+            };
+            existing.addEventListener('load', handleLoad);
+            existing.addEventListener('error', handleError);
         });
     }
 
@@ -56,9 +98,10 @@ function appendScript(src) {
         script.crossOrigin = 'anonymous';
         script.onload = () => {
             script.dataset.loaded = 'true';
-            resolve();
+            resolve(script);
         };
         script.onerror = (event) => {
+            script.remove();
             reject(event?.error || new Error(`Failed to load ${src}`));
         };
         document.head.appendChild(script);
@@ -95,24 +138,46 @@ function ensureSdkPrepared(ZoomMtgEmbedded) {
         .then(() => ZoomMtgEmbedded);
 }
 
+function tryLoadSdk(candidateIndex, previousErrors) {
+    if (candidateIndex >= CDN_SOURCES.length) {
+        const details = previousErrors
+            .map((entry) => ` - ${entry.src}: ${entry.error?.message || entry.error}`)
+            .join('\n');
+        const error = new Error(
+            previousErrors.length
+                ? `Zoom Meeting SDK를 불러오지 못했습니다. 시도한 경로:\n${details}`
+                : 'Zoom Meeting SDK를 불러오지 못했습니다.',
+        );
+        error.attemptErrors = previousErrors;
+        throw error;
+    }
+
+    const candidate = CDN_SOURCES[candidateIndex];
+
+    return appendScript(candidate.script)
+        .then(() => {
+            if (typeof window === 'undefined' || !window.ZoomMtgEmbedded) {
+                throw new Error('Zoom Meeting SDK 전역 객체가 존재하지 않습니다.');
+            }
+
+            candidate.styles.forEach((href) => appendStylesheet(href));
+            activeCdn = candidate;
+            return window.ZoomMtgEmbedded;
+        })
+        .catch((error) => {
+            const attempts = previousErrors.concat({ src: candidate.script, error });
+            return tryLoadSdk(candidateIndex + 1, attempts);
+        });
+}
+
 export function loadZoomEmbeddedSdk() {
     if (typeof window !== 'undefined' && window.ZoomMtgEmbedded) {
-        CSS_SOURCES.forEach(appendStylesheet);
+        activeCdn.styles?.forEach?.((href) => appendStylesheet(href));
         return ensureSdkPrepared(window.ZoomMtgEmbedded);
     }
 
     if (!loadingPromise) {
-        CSS_SOURCES.forEach(appendStylesheet);
-        loadingPromise = SCRIPT_SOURCES.reduce(
-            (promise, src) => promise.then(() => appendScript(src)),
-            Promise.resolve(),
-        )
-            .then(() => {
-                if (typeof window === 'undefined' || !window.ZoomMtgEmbedded) {
-                    throw new Error('Zoom Meeting SDK를 불러오지 못했습니다.');
-                }
-                return window.ZoomMtgEmbedded;
-            })
+        loadingPromise = tryLoadSdk(0, [])
             .then(ensureSdkPrepared)
             .catch((error) => {
                 loadingPromise = null;


### PR DESCRIPTION
## Summary
- add a resilient Zoom Meeting SDK loader that falls back across supported CDN endpoints
- update the meeting screen to read the active asset base from the loader when initialising the embedded client

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e01edeea9c83329024d883dae97020