### PR TITLE
Configure Zoom SDK request headers via environment

### DIFF
--- a/ZOOM_SDK_SETUP.md
+++ b/ZOOM_SDK_SETUP.md
@@ -1,0 +1,17 @@
+# Zoom Meeting SDK configuration
+
+The Zoom Meeting SDK only serves assets to origins that match the "Allow lists" configured for your SDK application in the Zoom App Marketplace. When the Electron renderer tries to download the SDK from `https://source.zoom.us`, the CDN validates the `Origin` and `Referer` headers. If those headers do not match one of the domains that you registered, Zoom responds with **403 Forbidden**, and the browser refuses to execute the script because it is returned as plain text.
+
+To prevent these 403 responses you must send the correct domain information with every request. The application now reads the domain from the `ZOOM_SDK_ALLOWED_DOMAIN` (or `ZOOM_SDK_DOMAIN` / `ZOOM_MEETING_SDK_DOMAIN`) environment variable at startup and rewrites the request headers automatically. This domain must match the value that you configured in the Zoom App Marketplace allow list.
+
+## Steps
+
+1. Open the Zoom App Marketplace and edit your Meeting SDK app. In the **Allow lists** section add the domain you want to use (for local development this is usually `https://localhost`).
+2. In this project create a `.env` file (or update your deployment configuration) and set:
+   ```env
+   ZOOM_SDK_ALLOWED_DOMAIN=https://localhost
+   ```
+   Replace `https://localhost` with any domain that you registered in the allow list.
+3. Restart the Electron application so the new header configuration is picked up.
+
+With the domain configured correctly the Zoom CDN serves the SDK script, the loader can initialize `ZoomMtgEmbedded`, and the Meeting screen no longer fails with `net::ERR_ABORTED 403 (Forbidden)`.

--- a/zoom-video-app/config/zoom-sdk.js
+++ b/zoom-video-app/config/zoom-sdk.js
@@ -1,0 +1,54 @@
+const DEFAULT_ZOOM_SDK_DOMAIN = 'https://localhost';
+
+const HEADER_SUFFIX = '/';
+
+function sanitizeDomain(value) {
+  if (!value) {
+    return '';
+  }
+
+  const trimmed = `${value}`.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  const normalized = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+
+  try {
+    const url = new URL(normalized);
+    if (!/^https?:$/i.test(url.protocol)) {
+      return '';
+    }
+    return `${url.protocol}//${url.host}`;
+  } catch (error) {
+    console.warn('[zoom-sdk] Ignoring invalid allowed domain value:', value, error);
+    return '';
+  }
+}
+
+function resolveZoomSdkDomain() {
+  const envValue =
+    process.env.ZOOM_SDK_ALLOWED_DOMAIN ||
+    process.env.ZOOM_SDK_DOMAIN ||
+    process.env.ZOOM_MEETING_SDK_DOMAIN ||
+    '';
+
+  const sanitized = sanitizeDomain(envValue);
+  if (sanitized) {
+    return sanitized;
+  }
+
+  return DEFAULT_ZOOM_SDK_DOMAIN;
+}
+
+function buildZoomSdkHeaderValues() {
+  const origin = resolveZoomSdkDomain();
+  const referer = `${origin.replace(/\/+$/, '')}${HEADER_SUFFIX}`;
+  return { origin, referer };
+}
+
+module.exports = {
+  DEFAULT_ZOOM_SDK_DOMAIN,
+  buildZoomSdkHeaderValues,
+  resolveZoomSdkDomain,
+};

--- a/zoom-video-app/src/main.js
+++ b/zoom-video-app/src/main.js
@@ -7,6 +7,7 @@ const {
   normalizeBackendUrl,
   getBackendOrigin,
 } = require('../config/backend-url');
+const { buildZoomSdkHeaderValues } = require('../config/zoom-sdk');
 const { buildConnectSrcValues } = require('../config/connect-src');
 const { buildCspString } = require('../config/csp');
 if (require('electron-squirrel-startup')) {
@@ -74,8 +75,7 @@ const ZOOM_REQUEST_PATTERNS = [
   '*://dmogdx0jrul3u.cloudfront.net/*',
 ];
 
-const ZOOM_ORIGIN = 'https://source.zoom.us';
-const ZOOM_REFERER = `${ZOOM_ORIGIN}/`;
+const { origin: ZOOM_ORIGIN, referer: ZOOM_REFERER } = buildZoomSdkHeaderValues();
 
 const FONT_HOSTS = ['https://fonts.gstatic.com'];
 const STYLE_HOSTS = ['https://fonts.googleapis.com'];
@@ -208,6 +208,8 @@ const installZoomRequestHardening = () => {
   if (!activeSession) {
     return;
   }
+
+  console.info('[zoom-sdk] Enforcing Zoom Meeting SDK headers with origin:', ZOOM_ORIGIN);
 
   activeSession.webRequest.onBeforeSendHeaders(
     { urls: ZOOM_REQUEST_PATTERNS },


### PR DESCRIPTION
## Summary
- add a Zoom Meeting SDK domain configuration helper that resolves the allowed domain from environment variables
- update the Electron main process to send the resolved origin and referer headers for every Zoom CDN request
- document how to register the domain with Zoom and configure the application to prevent 403 responses when loading the SDK

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e025595674833299bc9a0a91d2d45f