### PR TITLE
Fix Zoom Meeting SDK renderer bundling setup

### DIFF
--- a/zoom-video-app/package.json
+++ b/zoom-video-app/package.json
@@ -54,6 +54,7 @@
     "vm-browserify": "^1.1.2"
   },
   "dependencies": {
+    "@zoom/meetingsdk": "^3.11.0",
     "dotenv": "^16.5.0",
     "electron-squirrel-startup": "^1.0.1",
     "electron-store": "^10.0.1",

--- a/zoom-video-app/src/renderer.jsx
+++ b/zoom-video-app/src/renderer.jsx
@@ -1,6 +1,8 @@
 // src/renderer.jsx
 import React from 'react';
 import ReactDOM from 'react-dom/client'; // React 18의 새로운 Root API 사용
+import '@zoom/meetingsdk/dist/css/bootstrap.css';
+import '@zoom/meetingsdk/dist/css/react-select.css';
 import App from './App';
 import './index.css';
 

--- a/zoom-video-app/webpack.renderer.config.js
+++ b/zoom-video-app/webpack.renderer.config.js
@@ -3,6 +3,9 @@ const path = require('path');
 const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
+const SDK_VERSION = '3.11.0';
+const sdkDistRoot = path.resolve(__dirname, 'node_modules/@zoom/meetingsdk/dist');
+
 require('dotenv').config({ path: path.resolve(__dirname, '.env') });
 
 module.exports = {
@@ -32,6 +35,10 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.jsx'],
+    alias: {
+      'process/browser': require.resolve('process/browser'),
+      process: require.resolve('process/browser'),
+    },
     fallback: {
       "assert": require.resolve("assert/"),
       "buffer": require.resolve("buffer/"),
@@ -85,13 +92,23 @@ module.exports = {
     new CopyWebpackPlugin({
       patterns: [
         {
-          from: path.resolve(__dirname, 'node_modules/@zoom/videosdk/dist/lib'),
-          to: 'lib',
+          from: path.join(sdkDistRoot, 'lib'),
+          to: path.posix.join('zoomlib', SDK_VERSION, 'lib'),
           noErrorOnMissing: true,
         },
         {
-          from: path.resolve(__dirname, 'node_modules/@zoom/videosdk/dist/lib'),
-          to: path.posix.join('main_window', 'lib'),
+          from: path.join(sdkDistRoot, 'css'),
+          to: path.posix.join('zoomlib', SDK_VERSION, 'css'),
+          noErrorOnMissing: true,
+        },
+        {
+          from: path.join(sdkDistRoot, 'lib'),
+          to: path.posix.join('main_window', 'zoomlib', SDK_VERSION, 'lib'),
+          noErrorOnMissing: true,
+        },
+        {
+          from: path.join(sdkDistRoot, 'css'),
+          to: path.posix.join('main_window', 'zoomlib', SDK_VERSION, 'css'),
           noErrorOnMissing: true,
         },
       ],


### PR DESCRIPTION
## Summary
- add the Zoom Meeting SDK package and import its default styles
- ensure webpack resolves the process polyfill used by @zoom/meetingsdk
- copy the Meeting SDK css/lib assets into the renderer build so assetPath=/zoomlib/... works

## Testing
- `npm install` *(fails: @zoom/meetingsdk requires authenticated access from this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ed1bcf988332aeb0d977b8164972