### PR TITLE
Avoid requiring Wine when making Windows builds on macOS

### DIFF
--- a/zoom-video-app/forge.config.js
+++ b/zoom-video-app/forge.config.js
@@ -24,29 +24,43 @@ const devContentSecurityPolicy = buildCspString({
   connectSrc: Array.from(connectSrcValues),
 });
 
+const isRunningOnWindows = process.platform === 'win32';
+
+const makers = [];
+
+if (isRunningOnWindows) {
+  makers.push({
+    name: '@electron-forge/maker-squirrel',
+    config: {},
+  });
+} else {
+  makers.push({
+    name: '@electron-forge/maker-zip',
+    platforms: ['win32'],
+  });
+}
+
+makers.push(
+  {
+    name: '@electron-forge/maker-zip',
+    platforms: ['darwin'],
+  },
+  {
+    name: '@electron-forge/maker-deb',
+    config: {},
+  },
+  {
+    name: '@electron-forge/maker-rpm',
+    config: {},
+  },
+);
+
 module.exports = {
   packagerConfig: {
     asar: true,
   },
   rebuildConfig: {},
-  makers: [
-    {
-      name: '@electron-forge/maker-squirrel',
-      config: {},
-    },
-    {
-      name: '@electron-forge/maker-zip',
-      platforms: ['darwin'],
-    },
-    {
-      name: '@electron-forge/maker-deb',
-      config: {},
-    },
-    {
-      name: '@electron-forge/maker-rpm',
-      config: {},
-    },
-  ],
+  makers,
   plugins: [
     {
       name: '@electron-forge/plugin-auto-unpack-natives',


### PR DESCRIPTION
## Summary
- adjust the Electron Forge makers list to detect the host OS
- use the Squirrel maker only when running on Windows and fall back to a ZIP maker for win32 targets elsewhere
- keep the existing makers for macOS and Linux targets intact

## Testing
- npm run make -- --platform=win32 --arch=x64 *(fails in container: electron-forge not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e21bb6c63c833283864aa0c4490ae8