### PR TITLE
Enable Squirrel maker for win32 builds on non-Windows hosts

### DIFF
--- a/zoom-video-app/forge.config.js
+++ b/zoom-video-app/forge.config.js
@@ -24,23 +24,12 @@ const devContentSecurityPolicy = buildCspString({
   connectSrc: Array.from(connectSrcValues),
 });
 
-const isRunningOnWindows = process.platform === 'win32';
-
-const makers = [];
-
-if (isRunningOnWindows) {
-  makers.push({
+const makers = [
+  {
     name: '@electron-forge/maker-squirrel',
-    config: {},
-  });
-} else {
-  makers.push({
-    name: '@electron-forge/maker-zip',
     platforms: ['win32'],
-  });
-}
-
-makers.push(
+    config: {},
+  },
   {
     name: '@electron-forge/maker-zip',
     platforms: ['darwin'],
@@ -53,7 +42,7 @@ makers.push(
     name: '@electron-forge/maker-rpm',
     config: {},
   },
-);
+];
 
 module.exports = {
   packagerConfig: {


### PR DESCRIPTION
## Summary
- ensure the Squirrel Windows maker is always included when targeting win32 so cross-platform builds produce .squirrel packages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2263d056483329c5f94c03b1717ca