### PR TITLE
Fix renderer bundle name for packaged builds

### DIFF
--- a/zoom-video-app/webpack.renderer.config.js
+++ b/zoom-video-app/webpack.renderer.config.js
@@ -70,7 +70,7 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, '.webpack/renderer'),
-    filename: 'renderer.js',
+    filename: 'index.js',
     globalObject: 'window',
     publicPath: './',
   },


### PR DESCRIPTION
## Summary
- ensure the webpack renderer bundle is emitted as index.js so packaged apps load correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2865338dc8332839a19cd3f900496