### PR TITLE
Fix renderer require handling and harden Windows packaging

### DIFF
--- a/zoom-video-app/src/main.js
+++ b/zoom-video-app/src/main.js
@@ -103,6 +103,9 @@ const STYLE_HOSTS = ['https://fonts.googleapis.com'];
 const uniqueTokens = (values = []) =>
   Array.from(new Set(values.filter(Boolean)));
 
+const WINDOWS_APP_USER_MODEL_ID = process.env.ELECTRON_APP_USER_MODEL_ID
+  || 'com.zoomclass.desktop';
+
 const buildCspHeaderValue = () => {
   const directives = {
     'default-src': uniqueTokens([
@@ -271,6 +274,13 @@ function createWindow() {
 
 app.whenReady().then(() => {
   initializePersistentStore();
+  if (process.platform === 'win32') {
+    try {
+      app.setAppUserModelId(WINDOWS_APP_USER_MODEL_ID);
+    } catch (error) {
+      console.warn('Failed to set Windows AppUserModelID:', error);
+    }
+  }
   if (store) {
     overrideBackendUrl = readStoreBackendOverride();
     connectSrcAllowlist = computeConnectSrcAllowlist();

--- a/zoom-video-app/webpack.renderer.config.js
+++ b/zoom-video-app/webpack.renderer.config.js
@@ -29,6 +29,12 @@ module.exports = {
     // 브라우저 렌더러 + HMR 환경에 맞춤
     target: 'electron-renderer',
 
+    // Electron 렌더러 타깃이라도 Node 내장 모듈을 외부 의존성으로 두지 않도록 강제
+    // (nodeIntegration=false 환경에서는 require가 존재하지 않아 dev-server 번들이 깨진다)
+    externalsPresets: {
+        electronRenderer: false,
+    },
+
     // ✅ Webpack 5: Node 코어 모듈 폴리필 수동 제공
     resolve: {
         fallback: {


### PR DESCRIPTION
## Summary
- ensure the renderer bundle keeps webpack-provided polyfills instead of calling runtime require
- assign a stable Windows AppUserModelID during startup so the packaged app registers correctly

## Testing
- npm run lint
- npm run make -- --platform=win32 --arch=x64 *(fails: electron-forge not found in PATH in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a2b91a208332aab0d4545ab3b224