### PR TITLE
Handle Windows builds on non-Windows hosts

### DIFF
--- a/zoom-video-app/forge.config.js
+++ b/zoom-video-app/forge.config.js
@@ -24,18 +24,29 @@ const devContentSecurityPolicy = buildCspString({
   connectSrc: Array.from(connectSrcValues),
 });
 
+const isWindowsHost = process.platform === 'win32';
+
 const makers = [
-  {
-    name: '@electron-forge/maker-squirrel',
-    config: {
-      name: 'zoom-video-app',
-      authors: 'Your Company',
-      setupExe: 'ZoomClassSetup.exe',
-      noMsi: true,
-      shortcutFolderName: 'Zoom Class',
-    },
-    platforms: ['win32'],
-  },
+  ...(isWindowsHost
+    ? [
+        {
+          name: '@electron-forge/maker-squirrel',
+          config: {
+            name: 'zoom-video-app',
+            authors: 'Your Company',
+            setupExe: 'ZoomClassSetup.exe',
+            noMsi: true,
+            shortcutFolderName: 'Zoom Class',
+          },
+          platforms: ['win32'],
+        },
+      ]
+    : [
+        {
+          name: '@electron-forge/maker-zip',
+          platforms: ['win32'],
+        },
+      ]),
   {
     name: '@electron-forge/maker-zip',
     platforms: ['darwin'],


### PR DESCRIPTION
## Summary
- avoid running the Squirrel maker when the host OS is not Windows by falling back to the zip maker for win32 targets

## Testing
- npm run make -- --platform=win32 --arch=x64 *(fails: RequestError: read ECONNRESET)*

------
https://chatgpt.com/codex/tasks/task_e_68e3998a8b008332a87939b29450d2d2