### PR TITLE
Fix Windows renderer bundle filename

### DIFF
--- a/zoom-video-app/webpack.renderer.config.js
+++ b/zoom-video-app/webpack.renderer.config.js
@@ -70,7 +70,8 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, '.webpack/renderer'),
-    filename: 'renderer.js',
+    filename: 'index.js',
+    chunkFilename: '[name].js',
     globalObject: 'window',
     publicPath: './',
   },


### PR DESCRIPTION
## Summary
- ensure the renderer bundle is emitted as `index.js` so the packaged HTML loads correctly on Windows
- add an explicit chunk filename to keep any additional bundles discoverable during packaging

## Testing
- `npm run package -- --platform=win32 --arch=x64` *(fails: RequestError ECONNRESET while downloading Electron artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d354ba8c8332addec56838dd8578