### PR TITLE
Ensure Supabase Edge Function requests include auth headers

### DIFF
--- a/SUPABASE_SETUP.md
+++ b/SUPABASE_SETUP.md
@@ -58,6 +58,11 @@ npm run token-server
 ZOOM_SDK_KEY=your_zoom_sdk_key
 ZOOM_SDK_SECRET=your_zoom_sdk_secret
 BACKEND_BASE_URL=http://localhost:4000
+SUPABASE_FUNCTION_ANON_KEY=your_supabase_anon_key
 ```
+
+`SUPABASE_FUNCTION_ANON_KEY`에는 Supabase 프로젝트의 anon public 키를 입력하세요. Edge Function을 호출할 때는 Supabase에서
+요구하는 대로 `Authorization: Bearer <anon key>`와 `apikey` 헤더가 필요합니다. [Supabase Functions 공식 문서](https://supabase.com/docs/guides/functions#invoking-edge-functions)
+에 따르면 anon 키는 클라이언트에서 사용 가능한 공개 키입니다.
 
 이제 애플리케이션에서 회의 생성, 참여, 화면 공유, 캘린더 조회 기능을 사용할 수 있습니다.

--- a/zoom-video-app/webpack.renderer.config.js
+++ b/zoom-video-app/webpack.renderer.config.js
@@ -154,6 +154,10 @@ module.exports = {
       'process.env.ZOOM_SDK_KEY': JSON.stringify(process.env.ZOOM_SDK_KEY),
       'process.env.ZOOM_SDK_SECRET': JSON.stringify(process.env.ZOOM_SDK_SECRET),
       'process.env.BACKEND_BASE_URL': JSON.stringify(process.env.BACKEND_BASE_URL || process.env.TOKEN_SERVER_URL || ''),
+      'process.env.SUPABASE_FUNCTION_ANON_KEY': JSON.stringify(
+        process.env.SUPABASE_FUNCTION_ANON_KEY || process.env.SUPABASE_ANON_KEY || ''
+      ),
+      'process.env.SUPABASE_ANON_KEY': JSON.stringify(process.env.SUPABASE_ANON_KEY || ''),
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
     }),
     new webpack.NormalModuleReplacementPlugin(


### PR DESCRIPTION
## Summary
- add backend utilities to detect Supabase Edge Function URLs and attach required Authorization/apikey headers sourced from anon keys
- update lobby meeting creation/join/reservation flows to verify Supabase auth configuration and reuse the shared header helper
- expose Supabase anon key env vars to the renderer build and document the setup required for Edge Functions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3fde061508332b9923679b2ac1420