### PR TITLE
Ensure packaged app keeps configured backend URL

### DIFF
--- a/zoom-video-app/config/backend-url.js
+++ b/zoom-video-app/config/backend-url.js
@@ -1,4 +1,8 @@
-const DEFAULT_BACKEND_FALLBACK = '';
+const resolveRawBackendEnv = () =>
+  (process.env.BACKEND_BASE_URL ||
+    process.env.TOKEN_SERVER_URL ||
+    process.env.DEFAULT_BACKEND_FALLBACK ||
+    '').trim();
 
 const ensureHttpProtocol = (value) => {
   if (!value) {
@@ -17,7 +21,7 @@ const ensureHttpProtocol = (value) => {
   return trimmed;
 };
 
-const stripTrailingSlashes = (value) => value.replace(/\/+$/, '');
+const stripTrailingSlashes = (value = '') => `${value}`.replace(/\/+$/, '');
 
 const normalizeBackendUrl = (input) => {
   const ensured = ensureHttpProtocol(input);
@@ -47,6 +51,8 @@ const getBackendOrigin = (value) => {
     return '';
   }
 };
+
+const DEFAULT_BACKEND_FALLBACK = normalizeBackendUrl(resolveRawBackendEnv());
 
 module.exports = {
   DEFAULT_BACKEND_FALLBACK,

--- a/zoom-video-app/forge.config.js
+++ b/zoom-video-app/forge.config.js
@@ -1,4 +1,8 @@
 // zoom-video-app/forge.config.js
+const path = require('path');
+
+require('dotenv').config({ path: path.resolve(__dirname, '.env') });
+
 const { FusesPlugin } = require('@electron-forge/plugin-fuses');
 const { FuseV1Options, FuseVersion } = require('@electron/fuses');
 const {

--- a/zoom-video-app/webpack.main.config.js
+++ b/zoom-video-app/webpack.main.config.js
@@ -1,5 +1,11 @@
 // zoom-video-app/webpack.main.config.js (수정된 전체 파일)
 const path = require('path');
+const webpack = require('webpack');
+
+require('dotenv').config({ path: path.resolve(__dirname, '.env') });
+
+const rawBackendUrl = process.env.BACKEND_BASE_URL || process.env.TOKEN_SERVER_URL || '';
+const rawTokenServerUrl = process.env.TOKEN_SERVER_URL || '';
 
 module.exports = {
   mode: process.env.NODE_ENV || 'development',
@@ -26,4 +32,11 @@ module.exports = {
     path: path.resolve(__dirname, '.webpack/main'),
     filename: 'index.js',
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.BACKEND_BASE_URL': JSON.stringify(rawBackendUrl),
+      'process.env.TOKEN_SERVER_URL': JSON.stringify(rawTokenServerUrl),
+      'process.env.DEFAULT_BACKEND_FALLBACK': JSON.stringify(rawBackendUrl),
+    }),
+  ],
 };

--- a/zoom-video-app/webpack.renderer.config.js
+++ b/zoom-video-app/webpack.renderer.config.js
@@ -78,6 +78,9 @@ class NormalizeHtmlAssetPathsPlugin {
 
 require('dotenv').config({ path: path.resolve(__dirname, '.env') });
 
+const rawBackendUrl = process.env.BACKEND_BASE_URL || process.env.TOKEN_SERVER_URL || '';
+const rawTokenServerUrl = process.env.TOKEN_SERVER_URL || '';
+
 module.exports = {
   mode: process.env.NODE_ENV || 'development',
   devtool: process.env.NODE_ENV === 'development' ? 'eval-source-map' : 'source-map',
@@ -153,7 +156,9 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.env.ZOOM_SDK_KEY': JSON.stringify(process.env.ZOOM_SDK_KEY),
       'process.env.ZOOM_SDK_SECRET': JSON.stringify(process.env.ZOOM_SDK_SECRET),
-      'process.env.BACKEND_BASE_URL': JSON.stringify(process.env.BACKEND_BASE_URL || process.env.TOKEN_SERVER_URL || ''),
+      'process.env.BACKEND_BASE_URL': JSON.stringify(rawBackendUrl),
+      'process.env.TOKEN_SERVER_URL': JSON.stringify(rawTokenServerUrl),
+      'process.env.DEFAULT_BACKEND_FALLBACK': JSON.stringify(rawBackendUrl),
       'process.env.SUPABASE_FUNCTION_ANON_KEY': JSON.stringify(
         process.env.SUPABASE_FUNCTION_ANON_KEY || process.env.SUPABASE_ANON_KEY || ''
       ),


### PR DESCRIPTION
## Summary
- load environment variables for forge builds so CSP and packaging include the configured backend
- embed backend-related environment variables into the main and renderer bundles
- compute the default backend fallback from the build-time configuration so packaged apps keep the Supabase endpoint

## Testing
- npm --prefix zoom-video-app run lint

------
https://chatgpt.com/codex/tasks/task_e_68ea42595e048332979add9679f1b18a